### PR TITLE
Potential fix for code scanning alert no. 1: Useless regular-expression character escape

### DIFF
--- a/output/pcbs/bom/ibom.html
+++ b/output/pcbs/bom/ibom.html
@@ -1174,7 +1174,7 @@ function initUtils() {
     .concat(units.prefixes.nano)
     .concat(units.prefixes.pico);
   var allUnits = units.unitsShort.concat(units.unitsLong);
-  units.valueRegex = new RegExp("^([0-9\.]+)" +
+  units.valueRegex = new RegExp("^([0-9\\.]+)" +
     "\\s*(" + allPrefixes.join("|") + ")?" +
     "(" + allUnits.join("|") + ")?" +
     "(\\b.*)?$", "");


### PR DESCRIPTION
Potential fix for [https://github.com/dieseltravis/travis-ergogen-numpad/security/code-scanning/1](https://github.com/dieseltravis/travis-ergogen-numpad/security/code-scanning/1)

To fix the problem, replace the wrong single-escaped `\.` in the regex string with a double-escaped `\\.`. This ensures the resulting RegExp matches a literal dot, not any character. Specifically, in file `output/pcbs/bom/ibom.html`, on line 1177, change `[0-9\.]` to `[0-9\\.]`. No new imports or definitions are required; this is a simple string literal change. No other lines need to be changed; ensure that only the string literal in the RegExp constructor is edited as described.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
